### PR TITLE
Define a new terraform module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,67 @@
+provider "aws" {
+    alias = "module"
+    profile = "${var.aws_provider_profile}"
+    region = "${var.aws_provider_region}"
+    assume_role {
+        role_arn = "${var.aws_provider_assume_role_arn}"
+    }
+}
+
+data "aws_iam_policy_document" "saml_assume_role_policy" {
+    provider = "aws.module"
+    statement {
+        sid = "${var.aws_saml_provider_assume_policy_sid}"
+        actions = [
+            "sts:AssumeRoleWithSAML"
+        ]
+
+        principals {
+            type = "Federated"
+            identifiers = [
+                "${var.aws_saml_provider_arn}"
+            ]
+        }
+
+        condition {
+            test = "StringEquals"
+            variable = "saml:aud"
+            values = [
+                "https://signin.aws.amazon.com/saml"
+            ]
+        }
+
+        condition {
+            test = "ForAnyValue:StringLike"
+            variable ="saml:edupersonorgunitdn"
+            values = [
+                "${var.aws_saml_role_name}"
+            ]
+        }
+    }
+}
+
+resource "aws_iam_role" "saml_role" {
+    provider = "aws.module"
+    name = "${var.aws_saml_role_name}"
+    assume_role_policy = "${data.aws_iam_policy_document.saml_assume_role_policy.json}"
+}
+
+resource "github_team" "saml_role_github_team" {
+    name = "${var.aws_saml_role_name}"
+    description = "${aws_iam_role.saml_role.arn},${var.aws_saml_provider_arn}"
+    privacy = "${var.github_team_privacy}"
+}
+
+resource "github_team_membership" "saml_role_team_maintainers" {
+    count = "${length(var.aws_role_allowed_github_maintainer_users)}"
+    team_id = "${github_team.saml_role_github_team.id}"
+    username = "${element(var.aws_role_allowed_github_maintainer_users, count.index)}"
+    role = "maintainer"
+}
+
+resource "github_team_membership" "saml_role_team_members" {
+    count = "${length(var.aws_role_allowed_github_users)}"
+    team_id = "${github_team.saml_role_github_team.id}"
+    username = "${element(var.aws_role_allowed_github_users, count.index)}"
+    role = "member"
+}

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,7 @@
+output "role_arn" {
+    value = "${aws_iam_role.saml_role.arn}"
+}
+
+output "github_team_id" {
+    value = "${github_team.saml_role_github_team.id}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,42 @@
+variable "aws_provider_profile" {
+    description = "AWS profile to use for the AWS provider"
+    default = "default"
+}
+
+variable "aws_provider_region" {
+    description = "AWS region to use for the AWS provider"
+}
+
+variable "aws_provider_assume_role_arn" {
+    description = "ARN of role to assume for the AWS provider"
+    default = ""
+}
+
+variable "aws_saml_provider_arn" {
+    description = "ARN of the IAM SAML Provider"
+}
+
+variable "aws_saml_provider_assume_policy_sid" {
+    description = "SID to give the assume role policy for the SAML role"
+}
+
+variable "aws_saml_role_name" {
+    description = "Name of the role/team to create"
+}
+
+variable "github_team_privacy" {
+    description = "Privacy of the created GitHub team, can be secret or closed."
+    default = "secret"
+}
+
+variable "aws_role_allowed_github_maintainer_users" {
+    type = "list"
+    description = "List of the github users allowed to maintain this team on github"
+    default = []
+}
+
+variable "aws_role_allowed_github_users" {
+    type = "list"
+    description = "List of the users allowed to assume this role"
+    default = []
+}


### PR DESCRIPTION
This terraform module creates an IAM policy document defining the conditions for assuming the role:
- SAML audience must be AWS SignIn
- SAML user must have an eduPersonOrgUnitDN that matches the role team name.

Creates the AWS role for this alongside creating a GitHub team with the name of the team being the role name and the team description being the RoleARN,ProviderARN pair. This is used by our shibboleth scripts to allow GitHub team membership to define shibboleth SAML configuration for the AWS attribute resolver.

Finally the module allows specifying the GitHub users that are allowed to maintain the team on GitHub as well as those who are just members of the team and therefore have access to the role on AWS.