### PR TITLE
Allow specifying GitHub parent team ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ module "operations_admin_role" {
 | aws_saml_provider_assume_policy_sid | N/A | SID to give the assume role policy for the SAML role |
 | aws_saml_role_name | N/A | Name of the role/team to create |
 | github_team_privacy | secret | Privacy of the created GitHub team, can be secret or closed |
+| github_team_parent_id | N/A | Team ID for the parent team of the team being created. |
 | aws_role_allowed_github_maintainer_users | [] | List of the github users allowed to maintain this team on github and assume the role |
 | aws_role_allowed_github_users | [] | List of the github users allowed to assume this role |
 

--- a/main.tf
+++ b/main.tf
@@ -1,67 +1,74 @@
 provider "aws" {
-    alias = "module"
-    profile = "${var.aws_provider_profile}"
-    region = "${var.aws_provider_region}"
-    assume_role {
-        role_arn = "${var.aws_provider_assume_role_arn}"
-    }
+  alias   = "module"
+  profile = "${var.aws_provider_profile}"
+  region  = "${var.aws_provider_region}"
+
+  assume_role {
+    role_arn = "${var.aws_provider_assume_role_arn}"
+  }
 }
 
 data "aws_iam_policy_document" "saml_assume_role_policy" {
-    provider = "aws.module"
-    statement {
-        sid = "${var.aws_saml_provider_assume_policy_sid}"
-        actions = [
-            "sts:AssumeRoleWithSAML"
-        ]
+  provider = "aws.module"
 
-        principals {
-            type = "Federated"
-            identifiers = [
-                "${var.aws_saml_provider_arn}"
-            ]
-        }
+  statement {
+    sid = "${var.aws_saml_provider_assume_policy_sid}"
 
-        condition {
-            test = "StringEquals"
-            variable = "saml:aud"
-            values = [
-                "https://signin.aws.amazon.com/saml"
-            ]
-        }
+    actions = [
+      "sts:AssumeRoleWithSAML",
+    ]
 
-        condition {
-            test = "ForAnyValue:StringLike"
-            variable ="saml:edupersonorgunitdn"
-            values = [
-                "${var.aws_saml_role_name}"
-            ]
-        }
+    principals {
+      type = "Federated"
+
+      identifiers = [
+        "${var.aws_saml_provider_arn}",
+      ]
     }
+
+    condition {
+      test     = "StringEquals"
+      variable = "saml:aud"
+
+      values = [
+        "https://signin.aws.amazon.com/saml",
+      ]
+    }
+
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "saml:edupersonorgunitdn"
+
+      values = [
+        "${var.aws_saml_role_name}",
+      ]
+    }
+  }
 }
 
 resource "aws_iam_role" "saml_role" {
-    provider = "aws.module"
-    name = "${var.aws_saml_role_name}"
-    assume_role_policy = "${data.aws_iam_policy_document.saml_assume_role_policy.json}"
+  provider           = "aws.module"
+  name               = "${var.aws_saml_role_name}"
+  assume_role_policy = "${data.aws_iam_policy_document.saml_assume_role_policy.json}"
 }
 
 resource "github_team" "saml_role_github_team" {
-    name = "${var.aws_saml_role_name}"
-    description = "${aws_iam_role.saml_role.arn},${var.aws_saml_provider_arn}"
-    privacy = "${var.github_team_privacy}"
+  name           = "${var.aws_saml_role_name}"
+  description    = "${aws_iam_role.saml_role.arn},${var.aws_saml_provider_arn}"
+  privacy        = "${var.github_team_privacy}"
+  parent_team_id = "${var.github_team_parent_id}"
 }
 
 resource "github_team_membership" "saml_role_team_maintainers" {
-    count = "${length(var.aws_role_allowed_github_maintainer_users)}"
-    team_id = "${github_team.saml_role_github_team.id}"
-    username = "${element(var.aws_role_allowed_github_maintainer_users, count.index)}"
-    role = "maintainer"
+  count    = "${length(var.aws_role_allowed_github_maintainer_users)}"
+  team_id  = "${github_team.saml_role_github_team.id}"
+  username = "${element(var.aws_role_allowed_github_maintainer_users, count.index)}"
+  role     = "maintainer"
 }
 
 resource "github_team_membership" "saml_role_team_members" {
-    count = "${length(var.aws_role_allowed_github_users)}"
-    team_id = "${github_team.saml_role_github_team.id}"
-    username = "${element(var.aws_role_allowed_github_users, count.index)}"
-    role = "member"
+  count    = "${length(var.aws_role_allowed_github_users)}"
+  team_id  = "${github_team.saml_role_github_team.id}"
+  username = "${element(var.aws_role_allowed_github_users, count.index)}"
+  role     = "member"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,42 +1,47 @@
 variable "aws_provider_profile" {
-    description = "AWS profile to use for the AWS provider"
-    default = "default"
+  description = "AWS profile to use for the AWS provider"
+  default     = "default"
 }
 
 variable "aws_provider_region" {
-    description = "AWS region to use for the AWS provider"
+  description = "AWS region to use for the AWS provider"
 }
 
 variable "aws_provider_assume_role_arn" {
-    description = "ARN of role to assume for the AWS provider"
-    default = ""
+  description = "ARN of role to assume for the AWS provider"
+  default     = ""
 }
 
 variable "aws_saml_provider_arn" {
-    description = "ARN of the IAM SAML Provider"
+  description = "ARN of the IAM SAML Provider"
 }
 
 variable "aws_saml_provider_assume_policy_sid" {
-    description = "SID to give the assume role policy for the SAML role"
+  description = "SID to give the assume role policy for the SAML role"
 }
 
 variable "aws_saml_role_name" {
-    description = "Name of the role/team to create"
+  description = "Name of the role/team to create"
 }
 
 variable "github_team_privacy" {
-    description = "Privacy of the created GitHub team, can be secret or closed."
-    default = "secret"
+  description = "Privacy of the created GitHub team, can be secret or closed."
+  default     = "secret"
+}
+
+variable "github_team_parent_id" {
+  description = "Team ID for the parent team of the team being created."
+  default     = ""
 }
 
 variable "aws_role_allowed_github_maintainer_users" {
-    type = "list"
-    description = "List of the github users allowed to maintain this team on github and assume the role"
-    default = []
+  type        = "list"
+  description = "List of the github users allowed to maintain this team on github and assume the role"
+  default     = []
 }
 
 variable "aws_role_allowed_github_users" {
-    type = "list"
-    description = "List of the users allowed to assume this role"
-    default = []
+  type        = "list"
+  description = "List of the users allowed to assume this role"
+  default     = []
 }


### PR DESCRIPTION
Adds a terraform module variable and configuration to allow specifying the parent team ID for the new team being created.